### PR TITLE
Fix case harvester export URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Case Harvester
 Case Harvester is a project designed to scrape the [Maryland Judiciary Case Search](https://casesearch.courts.state.md.us/casesearch/inquiry-index.jsp) (MJCS) and build a near-complete database of Maryland court cases that can be queried and analyzed without the limitations of the MJCS interface. It is designed to leverage [Amazon Web Services (AWS)](https://aws.amazon.com/) for scalability and performance.
 
-Our database of cases (with criminal defendant PII redacted) is available to the public and can be found at [mdcaseexplorer.com](https://mdcaseexplorer.com), which is built using our [Case Explorer](https://github.com/dismantl/CaseExplorer) software. REST and GraphQL APIs are available. If you would like to download tables from our database exported monthly, you can find that at [exports.caseharvester.com](https://exports.caseharvester.com/).
+Our database of cases (with criminal defendant PII redacted) is available to the public and can be found at [mdcaseexplorer.com](https://mdcaseexplorer.com), which is built using our [Case Explorer](https://github.com/dismantl/CaseExplorer) software. REST and GraphQL APIs are available. If you would like to download tables from our database exported monthly, you can find that at [exports.mdcaseexplorer.com](https://exports.mdcaseexplorer.com/).
 
 > **NOTE: Unless you are modifying Case Harvester for specific purposes, please do not run your own instance so that MJCS is spared unneccesary load. Instead, use the options described above for viewing the data, or if you have an AWS account you are also welcome to clone our database directly.**
 


### PR DESCRIPTION
Fixed the case harvester export URL from https://exports.caseharvester.com/ to https://exports.mdcaseexplorer.com/.

https://exports.caseharvester.com/ returns a 404 response